### PR TITLE
Consistent naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ npm install content-range
 var contentRange = require('content-range');
 
 var header = contentRange.format({
-  name: 'items',
-  offset: 10,
+  unit: 'items',
+  first: 10,
   limit: 20,
-  count: 100
+  length: 100
 });
 
 console.log(header); // items 10-29/100
@@ -33,10 +33,10 @@ Format a content-range header.
 
 ```js
 var header = contentRange.format({
-  name: 'items',
-  offset: 10,
+  unit: 'items',
+  first: 10,
   limit: 20,
-  count: 100
+  length: 100
 });
 
 console.log(header); // items 10-29/100
@@ -49,7 +49,7 @@ Parse a content-range header.
 ```js
 var parts = contentRange.parse('items 10-29/100');
 
-console.log(parts); // { name: 'items', start: 10, end: 29, count: 100 }
+console.log(parts); // { unit: 'items', first: 10, last: 29, length: 100 }
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -18,22 +18,21 @@
    * Format the content-range header.
    *
    * @param {Object} options
-   * @param {String} options.name
-   * @param {Number} options.offset
+   * @param {String} options.unit
+   * @param {Number} options.start
    * @param {Number} options.limit
-   * @param {Number} options.count
+   * @param {Number} options.length
    */
 
   function format(options) {
-    options.count = typeof options.count === 'undefined' || options.count === null ?
-      '*' : options.count;
+    options.length = options.length == null ? '*' : options.length;
 
-    var start = options.offset;
-    var end = options.offset + options.limit - 1;
+    var first = options.first;
+    var last = options.last || (options.first + options.limit - 1);
 
-    if (end - start < 0) return options.name + ' */' + options.count;
+    if (last - first < 0) return options.unit + ' */' + options.length;
 
-    return options.name + ' ' + start + '-' + end + '/' + options.count;
+    return options.unit + ' ' + first + '-' + last + '/' + options.length;
   }
 
   /**
@@ -47,17 +46,17 @@
     var matches;
 
     if (matches = str.match(/^(\w+) (\d+)-(\d+)\/(\d+|\*)/)) return {
-        name: matches[1],
-        start: +matches[2],
-        end: +matches[3],
-        count: matches[4] === '*' ? null : +matches[4]
+        unit: matches[1],
+        first: +matches[2],
+        last: +matches[3],
+        length: matches[4] === '*' ? null : +matches[4]
       };
 
     if (matches = str.match(/^(\w+) \*\/(\d+|\*)/)) return {
-        name: matches[1],
-        start: null,
-        end: null,
-        count: matches[2] === '*' ? null : +matches[2]
+        unit: matches[1],
+        first: null,
+        last: null,
+        length: matches[2] === '*' ? null : +matches[2]
       };
 
     return null;

--- a/test.js
+++ b/test.js
@@ -5,54 +5,61 @@ describe('Content-range formatter', function () {
   describe('#format', function () {
     it('should format content', function () {
       assert.equal(contentRange.format({
-        name: 'items',
-        offset: 0,
+        unit: 'items',
+        first: 0,
         limit: 20,
-        count: 30
+        length: 30
       }), 'items 0-19/30');
 
       assert.equal(contentRange.format({
-        name: 'items',
-        offset: 20,
+        unit: 'items',
+        first: 20,
         limit: 50,
-        count: 400
+        length: 400
       }), 'items 20-69/400');
+
+      assert.equal(contentRange.format({
+        unit: 'items',
+        first: 20,
+        last: 29,
+        length: 100
+      }), 'items 20-29/100');
     });
 
-    it('should replace count by * if not defined', function () {
+    it('should replace length by * if not defined', function () {
       assert.equal(contentRange.format({
-        name: 'items',
-        offset: 0,
+        unit: 'items',
+        first: 0,
         limit: 20
       }), 'items 0-19/*');
 
       assert.equal(contentRange.format({
-        name: 'items',
-        offset: 0,
+        unit: 'items',
+        first: 0,
         limit: 20,
-        count: null
+        length: null
       }), 'items 0-19/*');
 
       assert.equal(contentRange.format({
-        name: 'items',
-        offset: 0,
+        unit: 'items',
+        first: 0,
         limit: 20,
-        count: 0
+        length: 0
       }), 'items 0-19/0');
     });
 
     it('should handle 0 result', function () {
       assert.equal(contentRange.format({
-        name: 'items',
-        offset: 5,
+        unit: 'items',
+        first: 5,
         limit: 0
       }), 'items */*');
 
       assert.equal(contentRange.format({
-        name: 'items',
-        offset: 5,
+        unit: 'items',
+        first: 5,
         limit: 0,
-        count: 20
+        length: 20
       }), 'items */20');
     });
   });
@@ -60,19 +67,19 @@ describe('Content-range formatter', function () {
   describe('#parse', function () {
     it('should parse header', function () {
       assert.deepEqual(contentRange.parse('items 0-19/30'), {
-        name: 'items',
-        start: 0,
-        end: 19,
-        count: 30
+        unit: 'items',
+        first: 0,
+        last: 19,
+        length: 30
       });
     });
 
-    it('should parse null start/end and null count', function () {
+    it('should parse null first/last and null length', function () {
       assert.deepEqual(contentRange.parse('items */*'), {
-        name: 'items',
-        start: null,
-        end: null,
-        count: null
+        unit: 'items',
+        first: null,
+        last: null,
+        length: null
       });
     });
 


### PR DESCRIPTION
[According to the RFC](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16), `start/offset` is called `first`, `end` is called `last`, `name` is called `unit`, and `count` is called `length`.

Also, `format` also accepts `end` instead of `limit`. With this change, `format` is now the inverse function of `parse`, so:

``` js
contentRange.format(contentRange.parse(rangeSpec)) === rangeSpec
```
